### PR TITLE
Fixed analytics for run-time usage

### DIFF
--- a/Assets/Svrf/Scripts/SvrfModel.cs
+++ b/Assets/Svrf/Scripts/SvrfModel.cs
@@ -13,7 +13,8 @@ namespace Svrf.Unity
         public bool WithOccluder = DefaultOptions.WithOccluder;
         public Shader ShaderOverride = DefaultOptions.ShaderOverride;
 
-        internal static SvrfApi SvrfApi;
+        private static SvrfApi _svrfApi;
+        internal static SvrfApi SvrfApi => _svrfApi ?? (_svrfApi = new SvrfApi());
 
         private static readonly SvrfModelOptions DefaultOptions = new SvrfModelOptions
         {
@@ -27,8 +28,6 @@ namespace Svrf.Unity
 
         public async void Start()
         {
-            CreateSvrfInstance();
-
             var model = (await SvrfApi.Media.GetByIdAsync(SvrfModelId)).Media;
             var options = new SvrfModelOptions
             {
@@ -55,14 +54,6 @@ namespace Svrf.Unity
             await SvrfModelUtility.AddSvrfModel(gameObject, model, options);
 
             return gameObject;
-        }
-
-        private static void CreateSvrfInstance()
-        {
-            if (SvrfApi == null)
-            {
-                SvrfApi = new SvrfApi();
-            }
         }
     }
 }

--- a/Assets/Svrf/Scripts/Utilities/Analytics.cs
+++ b/Assets/Svrf/Scripts/Utilities/Analytics.cs
@@ -14,7 +14,7 @@ namespace Svrf.Unity.Utilities
     internal static class SegmentTracking
     {
         private const string LibraryName = "Unity";
-        private const string SdkVersion = "1.1.0";
+        private const string SdkVersion = "1.1.1";
         private const string SegmentWriteKey = "VNcUInbeQ5UX2uM2hcXONRfwQqivs7CT";
 
         private const string FaceFilterEventName = "Face Filter Node Requested";


### PR DESCRIPTION
If a developer hasn't used `SvrfModel` script in Unity, the `Start` method won't be called and `SvrfApi` property would be null. We use this property in analytics instead of creating a new one to not spawn extra authentication calls. So put creating of new instance to property getter instead of `Start` method.

If `SvrfApi` instance is created just before an analytics call, we also need to wait for authentication call result to get app id. So awaiting `AuthenticateAsync` before the analytics call (if it's been already called, it doesn't spawn new auth request, so that's fine to call it to ensure we're authenticated).